### PR TITLE
Set update listener promise works

### DIFF
--- a/backend/app.ts
+++ b/backend/app.ts
@@ -1,7 +1,7 @@
 import express, { Express } from "express";
 import expressWs from "express-ws";
-import { createProcessor, IProcessor } from "./message";
-import { JsonValue, WebXdc, ReceivedUpdate } from "../types/webxdc-types";
+import { createProcessor, IProcessor, WebXdcMulti } from "./message";
+import { JsonValue, ReceivedUpdate } from "../types/webxdc-types";
 
 export type WebXdcDescription = {
   name: string;
@@ -58,7 +58,7 @@ export class Instance {
   constructor(
     public app: expressWs.Application,
     public port: number,
-    public webXdc: WebXdc
+    public webXdc: WebXdcMulti
   ) {}
 
   start() {
@@ -116,9 +116,9 @@ export class Instances {
         if (isSendUpdateMessage(parsed)) {
           instance.webXdc.sendUpdate(parsed.update, "update");
         } else if (isSetUpdateListenerMessage(parsed)) {
-          instance.webXdc.setUpdateListener((update) => {
-            console.log("gossip", update);
-            ws.send(JSON.stringify(update));
+          instance.webXdc.setUpdateListenerMulti((updates) => {
+            console.log("gossip", updates);
+            ws.send(JSON.stringify(updates));
           }, parsed.serial);
         } else {
           throw new Error(`Unknown message: ${JSON.stringify(parsed)}`);

--- a/backend/message.test.ts
+++ b/backend/message.test.ts
@@ -7,8 +7,8 @@ test("distribute to self", () => {
 
   const client0Heard: ReceivedUpdate<string>[] = [];
 
-  client0.setUpdateListener((update) => {
-    client0Heard.push(update);
+  client0.setUpdateListenerMulti((updates) => {
+    client0Heard.push(...updates);
   }, 0);
 
   client0.sendUpdate({ payload: "Hello" }, "update");
@@ -26,12 +26,12 @@ test("distribute to self and other", () => {
   const client0Heard: ReceivedUpdate<string>[] = [];
   const client1Heard: ReceivedUpdate<string>[] = [];
 
-  client0.setUpdateListener((update) => {
-    client0Heard.push(update);
+  client0.setUpdateListenerMulti((updates) => {
+    client0Heard.push(...updates);
   }, 0);
 
-  client1.setUpdateListener((update) => {
-    client1Heard.push(update);
+  client1.setUpdateListenerMulti((updates) => {
+    client1Heard.push(...updates);
   }, 0);
 
   client0.sendUpdate({ payload: "Hello" }, "update");
@@ -54,12 +54,12 @@ test("setUpdateListener serial should skip older", () => {
   const client0Heard: ReceivedUpdate<string>[] = [];
   const client1Heard: ReceivedUpdate<string>[] = [];
 
-  client0.setUpdateListener((update) => {
-    client0Heard.push(update);
+  client0.setUpdateListenerMulti((updates) => {
+    client0Heard.push(...updates);
   }, 0);
 
-  client1.setUpdateListener((update) => {
-    client1Heard.push(update);
+  client1.setUpdateListenerMulti((updates) => {
+    client1Heard.push(...updates);
   }, 1);
 
   client0.sendUpdate({ payload: "Hello" }, "update");
@@ -81,8 +81,8 @@ test("other starts listening later", () => {
   const client0Heard: ReceivedUpdate<string>[] = [];
   const client1Heard: ReceivedUpdate<string>[] = [];
 
-  client0.setUpdateListener((update) => {
-    client0Heard.push(update);
+  client0.setUpdateListenerMulti((updates) => {
+    client0Heard.push(...updates);
   }, 0);
 
   client0.sendUpdate({ payload: "Hello" }, "update");
@@ -95,8 +95,8 @@ test("other starts listening later", () => {
   // we only join later, so we haven't heard a thing yet
   expect(client1Heard).toMatchObject([]);
 
-  client1.setUpdateListener((update) => {
-    client1Heard.push(update);
+  client1.setUpdateListenerMulti((updates) => {
+    client1Heard.push(...updates);
   }, 0);
 
   expect(client0Heard).toMatchObject([
@@ -116,8 +116,8 @@ test("client is created later and needs to catch up", () => {
   const client0Heard: ReceivedUpdate<string>[] = [];
   const client1Heard: ReceivedUpdate<string>[] = [];
 
-  client0.setUpdateListener((update) => {
-    client0Heard.push(update);
+  client0.setUpdateListenerMulti((updates) => {
+    client0Heard.push(...updates);
   }, 0);
 
   client0.sendUpdate({ payload: "Hello" }, "update");
@@ -132,8 +132,8 @@ test("client is created later and needs to catch up", () => {
   expect(client1Heard).toMatchObject([]);
   const client1 = processor.createClient("3002");
 
-  client1.setUpdateListener((update) => {
-    client1Heard.push(update);
+  client1.setUpdateListenerMulti((updates) => {
+    client1Heard.push(...updates);
   }, 0);
 
   expect(client0Heard).toMatchObject([
@@ -154,8 +154,8 @@ test("other starts listening later but is partially caught up", () => {
   const client0Heard: ReceivedUpdate<string>[] = [];
   const client1Heard: ReceivedUpdate<string>[] = [];
 
-  client0.setUpdateListener((update) => {
-    client0Heard.push(update);
+  client0.setUpdateListenerMulti((updates) => {
+    client0Heard.push(...updates);
   }, 0);
 
   client0.sendUpdate({ payload: "Hello" }, "update");
@@ -168,8 +168,8 @@ test("other starts listening later but is partially caught up", () => {
   expect(client1Heard).toMatchObject([]);
 
   // start at 1, as we're already partially caught up
-  client1.setUpdateListener((update) => {
-    client1Heard.push(update);
+  client1.setUpdateListenerMulti((updates) => {
+    client1Heard.push(...updates);
   }, 1);
 
   expect(client0Heard).toMatchObject([

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,8 @@
 module.exports = {
   testEnvironment: "node",
   testMatch: [
-    "<rootDir>/backend/**/__tests__/**/*.{ts,tsx}",
     "<rootDir>/backend/**/?(*.)(test).{ts,tsx}",
+    "<rootDir>/sim/**/?(*.)(test).{ts,tsx}",
   ],
   // SWC instead of ts-jest
   transform: {

--- a/sim/create.ts
+++ b/sim/create.ts
@@ -1,0 +1,46 @@
+import { WebXdc, JsonValue, ReceivedUpdate } from "../types/webxdc-types";
+
+export type TransportMessageCallback = (data: JsonValue) => void;
+export type TransportConnectCallback = () => void;
+
+export type Transport = {
+  send(data: JsonValue): void;
+  onMessage(callback: TransportMessageCallback): void;
+  onConnect(callback: TransportConnectCallback): void;
+  address(): string;
+  name(): string;
+};
+
+export function createWebXdc(transport: Transport): WebXdc {
+  let resolveUpdateListenerPromise: (() => void) | null = null;
+
+  const webXdc: WebXdc = {
+    sendUpdate: (update, descr) => {
+      transport.send({ type: "sendUpdate", update, descr });
+      console.info("send", { update, descr });
+    },
+    setUpdateListener: (listener, serial = 0): Promise<void> => {
+      transport.onMessage((data) => {
+        const receivedUpdates: ReceivedUpdate<any>[] = data as any;
+        console.info("recv", receivedUpdates);
+        for (const update of receivedUpdates) {
+          listener(update);
+        }
+        if (resolveUpdateListenerPromise != null) {
+          resolveUpdateListenerPromise();
+          resolveUpdateListenerPromise = null;
+        }
+      });
+      transport.onConnect(() => {
+        transport.send({ type: "setUpdateListener", serial });
+      });
+      const promise = new Promise<void>((resolve) => {
+        resolveUpdateListenerPromise = resolve;
+      });
+      return promise;
+    },
+    selfAddr: transport.address(),
+    selfName: transport.name(),
+  };
+  return webXdc;
+}

--- a/sim/webxdc.test.ts
+++ b/sim/webxdc.test.ts
@@ -1,0 +1,120 @@
+import {
+  createWebXdc,
+  Transport,
+  TransportMessageCallback,
+  TransportConnectCallback,
+} from "./create";
+import { createProcessor, WebXdcMulti } from "../backend/message";
+
+// we have a transport that integrates directly with the backend
+class FakeTransport implements Transport {
+  messageCallback: TransportMessageCallback | null = null;
+  connectCallback: TransportConnectCallback | null = null;
+  _address: string;
+  _name: string;
+
+  constructor(public client: WebXdcMulti, address: string, name: string) {
+    this._address = address;
+    this._name = name;
+  }
+
+  send(data: any) {
+    if (data.type === "sendUpdate") {
+      const { update, descr } = data;
+      this.client.sendUpdate(update, descr);
+    } else if (data.type === "setUpdateListener") {
+      this.client.setUpdateListenerMulti((updates) => {
+        if (this.messageCallback != null) {
+          this.messageCallback(updates);
+        }
+      }, data.serial);
+    } else {
+      throw new Error(`Unknown data ${JSON.stringify(data)}`);
+    }
+  }
+  onMessage(callback: TransportMessageCallback) {
+    this.messageCallback = callback;
+  }
+  onConnect(callback: TransportConnectCallback) {
+    this.connectCallback = callback;
+  }
+  address() {
+    return this._address;
+  }
+  name() {
+    return this._name;
+  }
+
+  connect() {
+    if (this.connectCallback != null) {
+      this.connectCallback();
+    }
+  }
+}
+
+test("webxdc sends", async () => {
+  const processor = createProcessor();
+  const client = processor.createClient("a");
+
+  const fakeTransport = new FakeTransport(client, "A", "a");
+
+  const webXdc = createWebXdc(fakeTransport);
+  const updates: any[] = [];
+
+  const promise = webXdc.setUpdateListener((value) => {
+    updates.push(value);
+  }, 0);
+  fakeTransport.connect();
+  await promise;
+  webXdc.sendUpdate({ payload: "hello" }, "sent 1");
+  expect(updates).toEqual([
+    {
+      payload: "hello",
+      serial: 1,
+      max_serial: 1,
+    },
+  ]);
+});
+
+test("webxdc distributes", async () => {
+  const processor = createProcessor();
+  const clientA = processor.createClient("a");
+  const clientB = processor.createClient("b");
+  const fakeTransportA = new FakeTransport(clientA, "A", "a");
+  const fakeTransportB = new FakeTransport(clientB, "B", "b");
+
+  const webXdcA = createWebXdc(fakeTransportA);
+  const webXdcB = createWebXdc(fakeTransportB);
+  const updatesA: any[] = [];
+  const updatesB: any[] = [];
+
+  const promiseA = webXdcA.setUpdateListener((value) => {
+    updatesA.push(value);
+  }, 0);
+  fakeTransportA.connect();
+  await promiseA;
+
+  const promiseB = webXdcB.setUpdateListener((value) => {
+    updatesB.push(value);
+  }, 0);
+  fakeTransportB.connect();
+  await promiseB;
+
+  webXdcA.sendUpdate({ payload: "hello" }, "sent 1");
+  expect(updatesA).toEqual([
+    {
+      payload: "hello",
+      serial: 1,
+      max_serial: 1,
+    },
+  ]);
+  expect(updatesB).toEqual([
+    {
+      payload: "hello",
+      serial: 1,
+      max_serial: 1,
+    },
+  ]);
+});
+
+export {};

--- a/sim/webxdc.ts
+++ b/sim/webxdc.ts
@@ -30,16 +30,16 @@ const webXdc: WebXdc = {
       socket.removeEventListener("open", currentOpenEventListener);
     }
 
-    // if the socket is connecting, we send the information
-    // as soon as we're open
     if (socket.readyState === 0) {
+      // if the socket is connecting, we send the information
+      // as soon as we're open
       const openEventListener = (): void => {
         socket.send(JSON.stringify({ type: "setUpdateListener", serial }));
       };
       currentOpenEventListener = openEventListener;
       socket.addEventListener("open", openEventListener);
     } else if (socket.readyState === 1) {
-      // if it's open, we send the information immediately
+      // if it's already open, we send the information immediately
       socket.send(JSON.stringify({ type: "setUpdateListener", serial }));
     } else {
       throw new Error("Cannot access socket to register setUpdateListener");

--- a/types/webxdc-types.ts
+++ b/types/webxdc-types.ts
@@ -28,7 +28,6 @@ export type UpdateListener<T> = (update: ReceivedUpdate<T>) => void;
 
 export type SendUpdate<T> = (update: Update<T>, descr: string) => void;
 
-// XXX this should resolve a promise
 export type SetUpdateListener<T> = (
   listener: UpdateListener<T>,
   serial: number


### PR DESCRIPTION
To make the promise work we:

* changed the backend interaction so that it sends batches of updates at once to the client. This way the client can resolve the promise whenever it's received a batch, and an empty batch is sent in any case.

* abstracted out transport logic from the webxdc implementation on the client. This makes it possible to write some tests for the client.

