### PR TITLE
fix: apps being unable to `fetch()` anything

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ release date when you use `npm version` (see `README.md`).
 
 ## [Unreleased]
 
+### Fixed
+
+- Apps being unable to `fetch()` anything because of `connect-src` CSP
+
 ## [0.17.0][] - 2023-06-08
 
 ### Added

--- a/backend/app.ts
+++ b/backend/app.ts
@@ -10,7 +10,8 @@ import type { Info } from "../types/info";
 import type { Instance } from "../types/instance";
 
 const SIMULATOR_PATHS = ["/webxdc.js", "/webxdc", "/webxdc/.websocket"];
-const CONTENT_SECURITY_POLICY = `default-src 'self';\
+const DEFAULT_SRC_VALUES = "'self'";
+const CONTENT_SECURITY_POLICY = `default-src ${DEFAULT_SRC_VALUES};\
 style-src 'self' 'unsafe-inline' blob: ;\
 font-src 'self' data: blob: ;\
 script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: ;\
@@ -171,7 +172,9 @@ function getContentSecurityPolicy(
     return policy;
   }
 
-  return policy + `connect-src ${connectSrcUrls.join(" ")} ;`;
+  return (
+    policy + `connect-src ${DEFAULT_SRC_VALUES} ${connectSrcUrls.join(" ")} ;`
+  );
 }
 
 function wsUrl(httpUrl: string): string {


### PR DESCRIPTION
Because of `connect-src` CSP

Closes https://github.com/webxdc/webxdc-dev/issues/46

Introduced in dd8d0724