### PR TITLE
feat: simplify CLI usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ release date when you use `npm version` (see `README.md`).
 
 ## [Unreleased]
 
+### Added
+
+- Simpler ways to use CLI:
+
+  - make the only useful `run` comand the default one
+  - default `location` argument to the current directory
+  - treat `localhost:8080` as `http://localhost:8080`
+
+  Example: `webxdc-dev localhost:8080`
+
 ### Changed
 
 - use `@webxdc/types` instead of own types declaration

--- a/backend/program.ts
+++ b/backend/program.ts
@@ -22,10 +22,11 @@ export function createProgram(inject: Inject): Command {
     .version(getToolVersion());
 
   program
-    .command("run")
+    .command("run", { isDefault: true })
     .argument(
-      "<location>",
+      "[location]",
       "URL with dev server, path to .xdc file, or path to webxdc dist directory",
+      ".", // current directory
     )
     .option(
       "-p, --port <port>",


### PR DESCRIPTION
This shouldn't break previous valid usages

Sometimes when I want to test some webxdc app real quick I stop and think whether it's worth spending time on trying to recall how to use this tool. This should make things easier for people like me, and new users.