### PR TITLE
fix: apps being unable to use `data:` and `blob:`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ release date when you use `npm version` (see `README.md`).
 
 ### Fixed
 
-- Apps being unable to `fetch()` anything because of `connect-src` CSP
+- Apps being unable to `fetch()` anything or use `blob:` and `data:` resource because of `connect-src` CSP
 
 ## [0.17.0][] - 2023-06-08
 

--- a/backend/app.ts
+++ b/backend/app.ts
@@ -10,12 +10,18 @@ import type { Info } from "../types/info";
 import type { Instance } from "../types/instance";
 
 const SIMULATOR_PATHS = ["/webxdc.js", "/webxdc", "/webxdc/.websocket"];
-const DEFAULT_SRC_VALUES = "'self'";
-const CONTENT_SECURITY_POLICY = `default-src ${DEFAULT_SRC_VALUES};\
+// Real CSP is here. Need to periodically sync it.
+/*
+curl -L https://github.com/deltachat/deltachat-desktop/raw/master/src/main/deltachat/webxdc.ts | grep -i "default-src" -B 2 -A 8
+*/
+const CONTENT_SECURITY_POLICY = `default-src 'self';\
 style-src 'self' 'unsafe-inline' blob: ;\
 font-src 'self' data: blob: ;\
 script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: ;\
-img-src 'self' data: blob: ;`;
+connect-src 'self' data: blob: ;\
+img-src 'self' data: blob: ;\
+media-src 'self' data: blob: ;\
+webrtc 'block'"`;
 
 export type InjectExpress = (app: Express) => void;
 
@@ -172,8 +178,9 @@ function getContentSecurityPolicy(
     return policy;
   }
 
-  return (
-    policy + `connect-src ${DEFAULT_SRC_VALUES} ${connectSrcUrls.join(" ")} ;`
+  return policy.replace(
+    /connect-src (.*?);/,
+    `connect-src $1 ${connectSrcUrls.join(" ")} ;`
   );
 }
 


### PR DESCRIPTION
Follow-up to 1ffe114af44d

Example of a broken app:
https://codeberg.org/webxdc/checklist/src/commit/40d7b4801dbad8f85a1d9f8f3eb4a35c90d6abce