### PR TITLE
clear indexedDB when wiping other storage APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ release date when you use `npm version` (see `README.md`).
 ### Fixed
 
 - Apps being unable to `fetch()` anything or use `blob:` and `data:` resource because of `connect-src` CSP
+- `indexedDB` not getting cleared on `clear()`
 
 ## [0.17.0][] - 2023-06-08
 

--- a/sim/webxdc.ts
+++ b/sim/webxdc.ts
@@ -63,11 +63,21 @@ export class DevServerTransport implements Transport {
   clear() {
     window.localStorage.clear();
     window.sessionStorage.clear();
-    // XXX what about indexedDB?
-
-    // we want to reload the window otherwise we won't take the
-    // cleared localstorage into account
-    window.location.reload();
+    window.indexedDB.databases().then(results => {
+      Promise.all(results.map(result => {
+        return new Promise((resolve, reject) => {
+          const name = result?.name;
+          console.log(`Deleting indexedDB database: ${name}`);
+          const request = window.indexedDB.deleteDatabase(name);
+          request.onsuccess = ev => resolve(ev);
+          request.onerror = ev => reject(ev);
+        });
+      })).then(() => {
+        // we want to reload the window otherwise we won't take the
+        // cleared localstorage into account
+        window.location.reload();
+      });
+    });
   }
 
   address() {

--- a/sim/webxdc.ts
+++ b/sim/webxdc.ts
@@ -60,24 +60,25 @@ export class DevServerTransport implements Transport {
     }
   }
 
-  clear() {
+  async clear() {
     window.localStorage.clear();
     window.sessionStorage.clear();
-    window.indexedDB.databases().then(results => {
-      Promise.all(results.map(result => {
-        return new Promise((resolve, reject) => {
-          const name = result?.name;
-          console.log(`Deleting indexedDB database: ${name}`);
-          const request = window.indexedDB.deleteDatabase(name);
-          request.onsuccess = ev => resolve(ev);
-          request.onerror = ev => reject(ev);
-        });
-      })).then(() => {
-        // we want to reload the window otherwise we won't take the
-        // cleared localstorage into account
-        window.location.reload();
+
+    const databases = await window.indexedDB.databases();
+    
+    await Promise.all(databases.map(result => {
+      return new Promise((resolve, reject) => {
+        const name = result?.name;
+        console.log(`Deleting indexedDB database: ${name}`);
+        const request = window.indexedDB.deleteDatabase(name);
+        request.onsuccess = ev => resolve(ev);
+        request.onerror = ev => reject(ev);
       });
-    });
+    }));
+
+    // we want to reload the window otherwise we won't take the
+    // cleared localstorage into account
+    window.location.reload();
   }
 
   address() {


### PR DESCRIPTION
I discovered that indexedDB was not being cleared like localStorage and sessionStorage are, so I gave it a try. I have very little experience with typescript, however, so I just wrote everything as regular JavaScript. It seems to work, but I have no idea how the current code might impact any TypeScript tooling, and will need an expert to check that.

I found a comment indicating where the cleanup should happen, so somebody had at least thought of this issue before, which made it much easier than it might have otherwise been. 

Since most interaction with indexedDB is asynchronous I had to defer the `reload()` call to run after all databases have been cleared. Currently this is done with a `.then` invocation, but `.finally` might be more appropriate just in case there are unhandled errors.

I tested this in the context of the app I was developing and confirmed that it cleaned up the stray databases that were left behind from previous versions of the app.

It relies on the `indexedDB.databases()` method which used to have very inconsistent support, but which should now work [in any modern browser](https://developer.mozilla.org/en-US/docs/Web/API/IDBFactory/databases#browser_compatibility). the `indexedDB.deleteDatabase()` method likewise has [very broad support](https://developer.mozilla.org/en-US/docs/Web/API/IDBFactory/deleteDatabase#browser_compatibility).