### PR TITLE
Realtime Data API

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 *~
+.direnv

--- a/backend/app.ts
+++ b/backend/app.ts
@@ -84,7 +84,7 @@ export function createFrontend(
   app.post<any, { status: string }>("/fake-update", (req, res) => {
     const instanceId = Array.from(instances.instances.keys())[0];
     const instance = instances.instances.get(instanceId);
-    instance?.webXdc.sendUpdate({ payload: req.body }, "fake update");
+    instance?.webXdc.sendUpdate({ payload: req.body }, "");
     res.json({
       status: "ok",
     });

--- a/backend/instance.ts
+++ b/backend/instance.ts
@@ -125,7 +125,7 @@ export class Instances {
         const parsed = JSON.parse(msg);
         // XXX should validate parsed
         if (isSendUpdateMessage(parsed)) {
-          instance.webXdc.sendUpdate(parsed.update, parsed.descr);
+          instance.webXdc.sendUpdate(parsed.update, "");
         } else if (isSetUpdateListenerMessage(parsed)) {
           instance.webXdc.connect(
             (updates) => {

--- a/backend/instance.ts
+++ b/backend/instance.ts
@@ -22,6 +22,11 @@ type SendUpdateMessage = {
   descr: string;
 };
 
+type SendRealtimeMessage = {
+  type: "sendRealtime";
+  data: Uint8Array
+};
+
 type SetUpdateListenerMessage = {
   type: "setUpdateListener";
   serial: number;
@@ -126,6 +131,10 @@ export class Instances {
         // XXX should validate parsed
         if (isSendUpdateMessage(parsed)) {
           instance.webXdc.sendUpdate(parsed.update, "");
+        } else if (isSendRealtimeMessage(parsed)) {
+          instance.webXdc.sendRealtimeData(parsed.data);          
+        } else if (isJoinRealtimeMessage(parsed)) {
+          instance.webXdc.joinRealtimeChannel();          
         } else if (isSetUpdateListenerMessage(parsed)) {
           instance.webXdc.connect(
             (updates) => {
@@ -215,6 +224,14 @@ function broadcast(wss: Server<WebSocket>, data: string): boolean {
 
 function isSendUpdateMessage(value: any): value is SendUpdateMessage {
   return value.type === "sendUpdate";
+}
+
+function isSendRealtimeMessage(value: any): value is SendRealtimeMessage {
+  return value.type === "sendRealtime";
+}
+
+function isJoinRealtimeMessage(value: any): value is { type: "joinRealtime" } {
+  return value.type === "joinRealtime";
 }
 
 function isSetUpdateListenerMessage(

--- a/backend/instance.ts
+++ b/backend/instance.ts
@@ -135,7 +135,6 @@ export class Instances {
           instance.webXdc.sendRealtimeData(parsed.data);          
         } else if (isSetRealtimeListenerMessage(parsed)) {
           instance.webXdc.connectRealtime((data) => {
-            console.warn("broadcasting leeeeeel")
             return broadcast(wss, JSON.stringify({ type: "sendRealtime", data }));
           });          
         } else if (isSetUpdateListenerMessage(parsed)) {

--- a/backend/instance.ts
+++ b/backend/instance.ts
@@ -133,8 +133,11 @@ export class Instances {
           instance.webXdc.sendUpdate(parsed.update, "");
         } else if (isSendRealtimeMessage(parsed)) {
           instance.webXdc.sendRealtimeData(parsed.data);          
-        } else if (isJoinRealtimeMessage(parsed)) {
-          instance.webXdc.joinRealtimeChannel();          
+        } else if (isSetRealtimeListenerMessage(parsed)) {
+          instance.webXdc.connectRealtime((data) => {
+            console.warn("broadcasting leeeeeel")
+            return broadcast(wss, JSON.stringify({ type: "sendRealtime", data }));
+          });          
         } else if (isSetUpdateListenerMessage(parsed)) {
           instance.webXdc.connect(
             (updates) => {
@@ -230,8 +233,8 @@ function isSendRealtimeMessage(value: any): value is SendRealtimeMessage {
   return value.type === "sendRealtime";
 }
 
-function isJoinRealtimeMessage(value: any): value is { type: "joinRealtime" } {
-  return value.type === "joinRealtime";
+function isSetRealtimeListenerMessage(value: any): value is { type: "setRealtimeListener" } {
+  return value.type === "setRealtimeListener";
 }
 
 function isSetUpdateListenerMessage(

--- a/backend/message.test.ts
+++ b/backend/message.test.ts
@@ -26,10 +26,10 @@ test("distribute to self", () => {
     return true;
   }, 0);
 
-  client0.sendUpdate({ payload: "Hello" }, "update");
+  client0.sendUpdate({ payload: "Hello" }, "") ;
 
   expect(client0Heard).toMatchObject([
-    [{ payload: "Hello", serial: 1, max_serial: 1 }, "update"],
+    [{ payload: "Hello", serial: 1, max_serial: 1 }, ""],
   ]);
 
   expect(prepare(getMessages())).toEqual([
@@ -43,13 +43,13 @@ test("distribute to self", () => {
         serial: 1,
         max_serial: 1,
       },
-      descr: "update",
+      descr: "",
     },
     {
       type: "received",
       update: { payload: "Hello", serial: 1, max_serial: 1 },
       instanceId: "3001",
-      descr: "update",
+      descr: "",
     },
   ]);
 });
@@ -99,15 +99,15 @@ test("distribute to self and other", () => {
     return true;
   }, 0);
 
-  client0.sendUpdate({ payload: "Hello" }, "update");
-  client1.sendUpdate({ payload: "Bye" }, "update 2");
+  client0.sendUpdate({ payload: "Hello" }, "");
+  client1.sendUpdate({ payload: "Bye" }, "");
   expect(client0Heard).toMatchObject([
-    [{ payload: "Hello", serial: 1, max_serial: 1 }, "update"],
-    [{ payload: "Bye", serial: 2, max_serial: 2 }, "update 2"],
+    [{ payload: "Hello", serial: 1, max_serial: 1 }, ""],
+    [{ payload: "Bye", serial: 2, max_serial: 2 }, ""],
   ]);
   expect(client1Heard).toMatchObject([
-    [{ payload: "Hello", serial: 1, max_serial: 1 }, "update"],
-    [{ payload: "Bye", serial: 2, max_serial: 2 }, "update 2"],
+    [{ payload: "Hello", serial: 1, max_serial: 1 }, ""],
+    [{ payload: "Bye", serial: 2, max_serial: 2 }, ""],
   ]);
 
   expect(prepare(getMessages())).toEqual([
@@ -119,37 +119,37 @@ test("distribute to self and other", () => {
       type: "sent",
       instanceId: "3001",
       update: { payload: "Hello", serial: 1, max_serial: 1 },
-      descr: "update",
+      descr: "",
     },
     {
       type: "received",
       update: { payload: "Hello", serial: 1, max_serial: 1 },
       instanceId: "3001",
-      descr: "update",
+      descr: "",
     },
     {
       type: "received",
       update: { payload: "Hello", serial: 1, max_serial: 1 },
       instanceId: "3002",
-      descr: "update",
+      descr: "",
     },
     {
       type: "sent",
       instanceId: "3002",
       update: { payload: "Bye", serial: 2, max_serial: 2 },
-      descr: "update 2",
+      descr: "",
     },
     {
       type: "received",
       update: { payload: "Bye", serial: 2, max_serial: 2 },
       instanceId: "3001",
-      descr: "update 2",
+      descr: "",
     },
     {
       type: "received",
       update: { payload: "Bye", serial: 2, max_serial: 2 },
       instanceId: "3002",
-      descr: "update 2",
+      descr: "",
     },
   ]);
 });
@@ -172,14 +172,14 @@ test("setUpdateListener serial should skip older", () => {
     return true;
   }, 1);
 
-  client0.sendUpdate({ payload: "Hello" }, "update");
-  client0.sendUpdate({ payload: "Bye" }, "update 2");
+  client0.sendUpdate({ payload: "Hello" }, "");
+  client0.sendUpdate({ payload: "Bye" }, "");
   expect(client0Heard).toMatchObject([
-    [{ payload: "Hello", serial: 1, max_serial: 1 }, "update"],
-    [{ payload: "Bye", serial: 2, max_serial: 2 }, "update 2"],
+    [{ payload: "Hello", serial: 1, max_serial: 1 }, ""],
+    [{ payload: "Bye", serial: 2, max_serial: 2 }, ""],
   ]);
   expect(client1Heard).toMatchObject([
-    [{ payload: "Bye", serial: 2, max_serial: 2 }, "update 2"],
+    [{ payload: "Bye", serial: 2, max_serial: 2 }, ""],
   ]);
 });
 
@@ -197,12 +197,12 @@ test("other starts listening later", () => {
     return true;
   }, 0);
 
-  client0.sendUpdate({ payload: "Hello" }, "update");
-  client0.sendUpdate({ payload: "Bye" }, "update 2");
+  client0.sendUpdate({ payload: "Hello" }, "");
+  client0.sendUpdate({ payload: "Bye" }, "");
 
   expect(client0Heard).toMatchObject([
-    [{ payload: "Hello", serial: 1, max_serial: 1 }, "update"],
-    [{ payload: "Bye", serial: 2, max_serial: 2 }, "update 2"],
+    [{ payload: "Hello", serial: 1, max_serial: 1 }, ""],
+    [{ payload: "Bye", serial: 2, max_serial: 2 }, ""],
   ]);
   // we only join later, so we haven't heard a thing yet
   expect(client1Heard).toMatchObject([]);
@@ -213,12 +213,12 @@ test("other starts listening later", () => {
   }, 0);
 
   expect(client0Heard).toMatchObject([
-    [{ payload: "Hello", serial: 1, max_serial: 1 }, "update"],
-    [{ payload: "Bye", serial: 2, max_serial: 2 }, "update 2"],
+    [{ payload: "Hello", serial: 1, max_serial: 1 }, ""],
+    [{ payload: "Bye", serial: 2, max_serial: 2 }, ""],
   ]);
   expect(client1Heard).toMatchObject([
-    [{ payload: "Hello", serial: 1, max_serial: 2 }, "update"],
-    [{ payload: "Bye", serial: 2, max_serial: 2 }, "update 2"],
+    [{ payload: "Hello", serial: 1, max_serial: 2 }, ""],
+    [{ payload: "Bye", serial: 2, max_serial: 2 }, ""],
   ]);
 
   expect(prepare(getMessages())).toEqual([
@@ -228,25 +228,25 @@ test("other starts listening later", () => {
       type: "sent",
       instanceId: "3001",
       update: { payload: "Hello", serial: 1, max_serial: 1 },
-      descr: "update",
+      descr: "",
     },
     {
       type: "received",
       update: { payload: "Hello", serial: 1, max_serial: 1 },
       instanceId: "3001",
-      descr: "update",
+      descr: "",
     },
     {
       type: "sent",
       instanceId: "3001",
       update: { payload: "Bye", serial: 2, max_serial: 2 },
-      descr: "update 2",
+      descr: "",
     },
     {
       type: "received",
       update: { payload: "Bye", serial: 2, max_serial: 2 },
       instanceId: "3001",
-      descr: "update 2",
+      descr: "",
     },
     { type: "connect", instanceId: "3002" },
     { type: "clear", instanceId: "3002" },
@@ -254,13 +254,13 @@ test("other starts listening later", () => {
       type: "received",
       update: { payload: "Hello", serial: 1, max_serial: 2 },
       instanceId: "3002",
-      descr: "update",
+      descr: "",
     },
     {
       type: "received",
       update: { payload: "Bye", serial: 2, max_serial: 2 },
       instanceId: "3002",
-      descr: "update 2",
+      descr: "",
     },
   ]);
 });
@@ -277,12 +277,12 @@ test("client is created later and needs to catch up", () => {
     return true;
   }, 0);
 
-  client0.sendUpdate({ payload: "Hello" }, "update");
-  client0.sendUpdate({ payload: "Bye" }, "update 2");
+  client0.sendUpdate({ payload: "Hello" }, "");
+  client0.sendUpdate({ payload: "Bye" }, "");
 
   expect(client0Heard).toMatchObject([
-    [{ payload: "Hello", serial: 1, max_serial: 1 }, "update"],
-    [{ payload: "Bye", serial: 2, max_serial: 2 }, "update 2"],
+    [{ payload: "Hello", serial: 1, max_serial: 1 }, ""],
+    [{ payload: "Bye", serial: 2, max_serial: 2 }, ""],
   ]);
 
   // we only join later, so we haven't heard a thing yet
@@ -295,12 +295,12 @@ test("client is created later and needs to catch up", () => {
   }, 0);
 
   expect(client0Heard).toMatchObject([
-    [{ payload: "Hello", serial: 1, max_serial: 1 }, "update"],
-    [{ payload: "Bye", serial: 2, max_serial: 2 }, "update 2"],
+    [{ payload: "Hello", serial: 1, max_serial: 1 }, ""],
+    [{ payload: "Bye", serial: 2, max_serial: 2 }, ""],
   ]);
   expect(client1Heard).toMatchObject([
-    [{ payload: "Hello", serial: 1, max_serial: 2 }, "update"],
-    [{ payload: "Bye", serial: 2, max_serial: 2 }, "update 2"],
+    [{ payload: "Hello", serial: 1, max_serial: 2 }, ""],
+    [{ payload: "Bye", serial: 2, max_serial: 2 }, ""],
   ]);
 });
 
@@ -317,11 +317,11 @@ test("other starts listening later but is partially caught up", () => {
     return true;
   }, 0);
 
-  client0.sendUpdate({ payload: "Hello" }, "update");
-  client0.sendUpdate({ payload: "Bye" }, "update 2");
+  client0.sendUpdate({ payload: "Hello" }, "");
+  client0.sendUpdate({ payload: "Bye" }, "");
   expect(client0Heard).toMatchObject([
-    [{ payload: "Hello", serial: 1, max_serial: 1 }, "update"],
-    [{ payload: "Bye", serial: 2, max_serial: 2 }, "update 2"],
+    [{ payload: "Hello", serial: 1, max_serial: 1 }, ""],
+    [{ payload: "Bye", serial: 2, max_serial: 2 }, ""],
   ]);
   // we only join later, so we haven't heard a thing yet
   expect(client1Heard).toMatchObject([]);
@@ -333,11 +333,11 @@ test("other starts listening later but is partially caught up", () => {
   }, 1);
 
   expect(client0Heard).toMatchObject([
-    [{ payload: "Hello", serial: 1, max_serial: 1 }, "update"],
-    [{ payload: "Bye", serial: 2, max_serial: 2 }, "update 2"],
+    [{ payload: "Hello", serial: 1, max_serial: 1 }, ""],
+    [{ payload: "Bye", serial: 2, max_serial: 2 }, ""],
   ]);
   expect(client1Heard).toMatchObject([
-    [{ payload: "Bye", serial: 2, max_serial: 2 }, "update 2"],
+    [{ payload: "Bye", serial: 2, max_serial: 2 }, ""],
   ]);
 });
 
@@ -511,16 +511,16 @@ test("connect with clear means we get no catchup if no new updates", () => {
     },
   );
 
-  client0.sendUpdate({ payload: "Hello" }, "update");
-  client0.sendUpdate({ payload: "Bye" }, "update 2");
+  client0.sendUpdate({ payload: "Hello" }, "");
+  client0.sendUpdate({ payload: "Bye" }, "");
 
   // now we clear
   processor.clear();
 
   expect(client0Heard).toMatchObject([
     "cleared",
-    [{ payload: "Hello", serial: 1, max_serial: 1 }, "update"],
-    [{ payload: "Bye", serial: 2, max_serial: 2 }, "update 2"],
+    [{ payload: "Hello", serial: 1, max_serial: 1 }, ""],
+    [{ payload: "Bye", serial: 2, max_serial: 2 }, ""],
     "cleared",
   ]);
 
@@ -542,8 +542,8 @@ test("connect with clear means we get no catchup if no new updates", () => {
 
   expect(client0Heard).toMatchObject([
     "cleared",
-    [{ payload: "Hello", serial: 1, max_serial: 1 }, "update"],
-    [{ payload: "Bye", serial: 2, max_serial: 2 }, "update 2"],
+    [{ payload: "Hello", serial: 1, max_serial: 1 }, ""],
+    [{ payload: "Bye", serial: 2, max_serial: 2 }, ""],
     "cleared",
   ]);
   expect(client1Heard).toMatchObject(["cleared"]);
@@ -569,8 +569,8 @@ test("connect with clear means catchup only with updates after clear", () => {
     },
   );
 
-  client0.sendUpdate({ payload: "Hello" }, "update");
-  client0.sendUpdate({ payload: "Bye" }, "update 2");
+  client0.sendUpdate({ payload: "Hello" }, "");
+  client0.sendUpdate({ payload: "Bye" }, "");
 
   processor.clear();
 
@@ -579,8 +579,8 @@ test("connect with clear means catchup only with updates after clear", () => {
 
   expect(client0Heard).toMatchObject([
     "cleared",
-    [{ payload: "Hello", serial: 1, max_serial: 1 }, "update"],
-    [{ payload: "Bye", serial: 2, max_serial: 2 }, "update 2"],
+    [{ payload: "Hello", serial: 1, max_serial: 1 }, ""],
+    [{ payload: "Bye", serial: 2, max_serial: 2 }, ""],
     "cleared",
     [{ payload: "Aftermath", serial: 1, max_serial: 1 }, "update 3"],
   ]);
@@ -603,8 +603,8 @@ test("connect with clear means catchup only with updates after clear", () => {
 
   expect(client0Heard).toMatchObject([
     "cleared",
-    [{ payload: "Hello", serial: 1, max_serial: 1 }, "update"],
-    [{ payload: "Bye", serial: 2, max_serial: 2 }, "update 2"],
+    [{ payload: "Hello", serial: 1, max_serial: 1 }, ""],
+    [{ payload: "Bye", serial: 2, max_serial: 2 }, ""],
     "cleared",
     [{ payload: "Aftermath", serial: 1, max_serial: 1 }, "update 3"],
   ]);
@@ -620,25 +620,25 @@ test("connect with clear means catchup only with updates after clear", () => {
       type: "sent",
       instanceId: "3001",
       update: { payload: "Hello", serial: 1, max_serial: 1 },
-      descr: "update",
+      descr: "",
     },
     {
       type: "received",
       update: { payload: "Hello", serial: 1, max_serial: 1 },
       instanceId: "3001",
-      descr: "update",
+      descr: "",
     },
     {
       type: "sent",
       instanceId: "3001",
       update: { payload: "Bye", serial: 2, max_serial: 2 },
-      descr: "update 2",
+      descr: "",
     },
     {
       type: "received",
       update: { payload: "Bye", serial: 2, max_serial: 2 },
       instanceId: "3001",
-      descr: "update 2",
+      descr: "",
     },
     { type: "clear", instanceId: "3001" },
     {
@@ -683,9 +683,9 @@ test("distribute to self and other, but other was disconnected", () => {
     return false;
   }, 0);
 
-  client0.sendUpdate({ payload: "Hello" }, "update");
+  client0.sendUpdate({ payload: "Hello" }, "");
   expect(client0Heard).toMatchObject([
-    [{ payload: "Hello", serial: 1, max_serial: 1 }, "update"],
+    [{ payload: "Hello", serial: 1, max_serial: 1 }, ""],
   ]);
   expect(client1Heard).toMatchObject([]);
 
@@ -698,13 +698,13 @@ test("distribute to self and other, but other was disconnected", () => {
       type: "sent",
       instanceId: "3001",
       update: { payload: "Hello", serial: 1, max_serial: 1 },
-      descr: "update",
+      descr: "",
     },
     {
       type: "received",
       update: { payload: "Hello", serial: 1, max_serial: 1 },
       instanceId: "3001",
-      descr: "update",
+      descr: "",
     },
   ]);
 });
@@ -773,7 +773,7 @@ test("instanceColor", () => {
     return true;
   }, 0);
 
-  client0.sendUpdate({ payload: "Hello" }, "update");
+  client0.sendUpdate({ payload: "Hello" }, "");
 
   const instanceColors = getMessages().map((message) => message.instanceColor);
   expect(instanceColors).toEqual([
@@ -815,7 +815,7 @@ test("timestamp", async () => {
 
   await waitFor(10);
 
-  client0.sendUpdate({ payload: "Hello" }, "update");
+  client0.sendUpdate({ payload: "Hello" }, "");
 
   await waitFor(10);
 

--- a/backend/message.test.ts
+++ b/backend/message.test.ts
@@ -64,7 +64,7 @@ test("Send realtime", () => {
   const client0Heard: string[] = [];
   const client1Heard: string[] = [];
 
-  const rt0 = client0.joinRealtimeChannel()
+  /* const rt0 = client0.joinRealtimeChannel()
   const rt1 = client1.joinRealtimeChannel()
 
   const decoder = new TextDecoder()
@@ -78,9 +78,8 @@ test("Send realtime", () => {
   expect(client1Heard).toMatchObject([
     "hi"
   ])
-  expect(client0Heard).toMatchObject([])
+  expect(client0Heard).toMatchObject([]) */
 });
-
 test("distribute to self and other", () => {
   const [getMessages, onMessage] = track();
   const processor = createProcessor(onMessage);
@@ -576,7 +575,7 @@ test("connect with clear means catchup only with updates after clear", () => {
   processor.clear();
 
   // the aftermath update, which the newly connecting client should get
-  client0.sendUpdate({ payload: "Aftermath" }, "update 3");
+  client0.sendUpdate({ payload: "Aftermath" }, "");
 
   expect(client0Heard).toMatchObject([
     "cleared",

--- a/backend/message.test.ts
+++ b/backend/message.test.ts
@@ -26,7 +26,7 @@ test("distribute to self", () => {
     return true;
   }, 0);
 
-  client0.sendUpdate({ payload: "Hello" }, "") ;
+  client0.sendUpdate({ payload: "Hello" }, "");
 
   expect(client0Heard).toMatchObject([
     [{ payload: "Hello", serial: 1, max_serial: 1 }, ""],
@@ -63,21 +63,22 @@ test("Send realtime", () => {
 
   const client0Heard: string[] = [];
   const client1Heard: string[] = [];
-  
+
   const rt0 = client0.joinRealtimeChannel()
   const rt1 = client1.joinRealtimeChannel()
 
   const decoder = new TextDecoder()
-  rt0.setListener((data) => { client0Heard.push(decoder.decode(data))})
-  rt1.setListener((data) => { client1Heard.push(decoder.decode(data))})
+  rt0.setListener((data) => { client0Heard.push(decoder.decode(data)) })
+  rt1.setListener((data) => { client1Heard.push(decoder.decode(data)) })
 
   const encoder = new TextEncoder()
-  
+
   rt0.send(new Uint8Array(encoder.encode("hi")))
-  
-  expect(client0Heard).toMatchObject([
+
+  expect(client1Heard).toMatchObject([
     "hi"
   ])
+  expect(client0Heard).toMatchObject([])
 });
 
 test("distribute to self and other", () => {

--- a/backend/message.test.ts
+++ b/backend/message.test.ts
@@ -54,6 +54,32 @@ test("distribute to self", () => {
   ]);
 });
 
+
+test("Send realtime", () => {
+  const [getMessages, onMessage] = track();
+  const processor = createProcessor(onMessage);
+  const client0 = processor.createClient("3001");
+  const client1 = processor.createClient("3002");
+
+  const client0Heard: string[] = [];
+  const client1Heard: string[] = [];
+  
+  const rt0 = client0.joinRealtimeChannel()
+  const rt1 = client1.joinRealtimeChannel()
+
+  const decoder = new TextDecoder()
+  rt0.setListener((data) => { client0Heard.push(decoder.decode(data))})
+  rt1.setListener((data) => { client1Heard.push(decoder.decode(data))})
+
+  const encoder = new TextEncoder()
+  
+  rt0.send(new Uint8Array(encoder.encode("hi")))
+  
+  expect(client0Heard).toMatchObject([
+    "hi"
+  ])
+});
+
 test("distribute to self and other", () => {
   const [getMessages, onMessage] = track();
   const processor = createProcessor(onMessage);

--- a/backend/message.ts
+++ b/backend/message.ts
@@ -4,7 +4,6 @@ import {
   SendingStatusUpdate,
   Webxdc,
 } from "@webxdc/types";
-import { ReadLine } from "readline";
 import type { Message } from "../types/message";
 import { getColorForId } from "./color";
 
@@ -25,6 +24,7 @@ type Connect = (
 export type WebXdcMulti = {
   connect: Connect;
   sendUpdate: Webxdc<any>["sendUpdate"];
+  sendRealtimeData: (data: Uint8Array) => void;
   joinRealtimeChannel: Webxdc<any>["joinRealtimeChannel"]
 };
 
@@ -40,9 +40,9 @@ export interface IProcessor {
   removeClient(id: string): void;
 }
 
-class RTL implements RealtimeListener {
+export class RTL implements RealtimeListener {
   private trashed = false; 
-  private listener: (data: Uint8Array) => void  = (data) => { }  
+  private listener: (data: Uint8Array) => void  = () => { }  
   
   constructor(private sendHook: (data: Uint8Array) => void) {}
 

--- a/backend/message.ts
+++ b/backend/message.ts
@@ -127,9 +127,6 @@ class Client implements WebXdcMulti {
   }
   
   receiveRealtime(data: Uint8Array) {
-    if (this.updateListener == null || this.updateSerial == null) {
-      return;
-    }
     if (this.realtime && this.realtime.listener) 
       this.realtime?.listener(data)
   } 
@@ -200,7 +197,8 @@ class Processor implements IProcessor {
       timestamp: Date.now(),
     });
     for (const client of this.clients) {
-      client.receiveRealtime(data);
+      if (client.id != instanceId)
+        client.receiveRealtime(data);
     }
   }
 

--- a/backend/message.ts
+++ b/backend/message.ts
@@ -1,5 +1,5 @@
 import {
-  RealtimeListener,
+  RealtimeListener as WebxdcRealtimeListener,
   ReceivedStatusUpdate,
   SendingStatusUpdate,
   Webxdc,
@@ -40,11 +40,14 @@ export interface IProcessor {
   removeClient(id: string): void;
 }
 
-export class RTL implements RealtimeListener {
-  private trashed = false; 
-  private listener: (data: Uint8Array) => void  = () => { }  
-  
-  constructor(private sendHook: (data: Uint8Array) => void) {}
+export class RealtimeListener implements WebxdcRealtimeListener {
+  private trashed = false;
+  private listener: (data: Uint8Array) => void = () => { }
+
+  constructor(
+    private sendHook: (data: Uint8Array) => void = () => { },
+    private leaveHook: () => void = () => { }
+  ) { }
 
   is_trashed(): boolean {
     return this.trashed;
@@ -73,13 +76,14 @@ export class RTL implements RealtimeListener {
   }
 
   leave() {
+    this.leaveHook()
     this.trashed = true;
   }
 }
 
 class Client implements WebXdcMulti {
   updateListener: UpdateListenerMulti | null = null;
-  realtime: RTL | null = null;
+  realtime: RealtimeListener | null = null;
   clearListener: ClearListener | null = null;
   updateSerial: number | null = null;
   deleteListener: DeleteListener | null = null;
@@ -161,10 +165,8 @@ class Client implements WebXdcMulti {
   }
 
   joinRealtimeChannel(): RealtimeListener {
-    if (this.realtime && !this.realtime.is_trashed) {
-      throw new Error("The old realtime instance has to be trashed first")
-    }
-    this.realtime = new RTL((data) => {
+    console.log("joined realtime")
+    this.realtime = new RealtimeListener((data) => {
       this.sendRealtimeData(data)
     })
     return this.realtime
@@ -214,19 +216,24 @@ class Processor implements IProcessor {
     instanceId: string,
     data: Uint8Array,
   ) {
+    console.log("distributing")
     this.onMessage({
-      type: "realtime-sent",
+      type: "sendRealtime",
       instanceId: instanceId,
       instanceColor: getColorForId(instanceId),
       data,
       timestamp: Date.now(),
     });
     for (const client of this.clients) {
-      if (client.id != instanceId && client.realtime)
+      if (client.id != instanceId) {
+        if (!client.realtime) {
+          continue
+          console.warn(`client ${instanceId} has not joined realtime`)
+        }
         client.realtime.receive(data);
+      }
     }
   }
-
 
   distribute(
     instanceId: string,

--- a/backend/message.ts
+++ b/backend/message.ts
@@ -106,7 +106,6 @@ class Client implements WebXdcMulti {
   }
 
   connectRealtime(listener: RealtimeListenerListener) {
-    console.warn("connecting realtime")
     this.processor.onMessage({
       type: "connect-realtime",
       instanceId: this.id,
@@ -198,7 +197,6 @@ class Client implements WebXdcMulti {
     if (this.realtimeListener == null) {
       return;
     }
-    console.warn("hiiiii");
     this.realtimeListener(data);
   }
 

--- a/backend/message.ts
+++ b/backend/message.ts
@@ -13,6 +13,7 @@ type UpdateListenerMulti = (
 
 type ClearListener = () => boolean;
 type DeleteListener = () => boolean;
+type RealtimeListenerListener = (data: Uint8Array) => boolean
 
 type Connect = (
   updateListener: UpdateListenerMulti,
@@ -83,6 +84,7 @@ export class RealtimeListener implements WebxdcRealtimeListener {
 
 class Client implements WebXdcMulti {
   updateListener: UpdateListenerMulti | null = null;
+  realtimeListener: RealtimeListenerListener | null = null;
   realtime: RealtimeListener | null = null;
   clearListener: ClearListener | null = null;
   updateSerial: number | null = null;
@@ -99,6 +101,32 @@ class Client implements WebXdcMulti {
 
   sendRealtimeData(data: Uint8Array): void {
     this.processor.distributeRealtime(this.id, data);
+  }
+
+  connectRealtime(listener: RealtimeListenerListener) {
+    this.processor.onMessage({
+      type: "connect-realtime",
+      instanceId: this.id,
+      instanceColor: getColorForId(this.id),
+      timestamp: Date.now(),
+    });
+
+    
+    const realtimeListener= (data: Uint8Array) => {
+      const hasReceived = listener(data);
+      if (hasReceived) {
+          this.processor.onMessage({
+            type: "realtime-received",
+            data,
+            instanceId: this.id,
+            instanceColor: getColorForId(this.id),
+            timestamp: Date.now(),
+          });
+      }
+      return hasReceived;
+    };
+
+    this.realtimeListener = realtimeListener
   }
 
   connect(
@@ -162,6 +190,13 @@ class Client implements WebXdcMulti {
       return;
     }
     this.updateListener([[update, descr]]);
+  }
+
+  receiveRealtime(data: Uint8Array) {
+    if (this.realtimeListener == null) {
+      return;
+    }
+    this.realtimeListener(data);
   }
 
   joinRealtimeChannel(): RealtimeListener {
@@ -230,7 +265,7 @@ class Processor implements IProcessor {
           continue
           console.warn(`client ${instanceId} has not joined realtime`)
         }
-        client.realtime.receive(data);
+        client.receiveRealtime(data)
       }
     }
   }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,25 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1731676054,
+        "narHash": "sha256-OZiZ3m8SCMfh3B6bfGC/Bm4x3qc1m2SVEAlkV6iY7Yg=",
+        "rev": "5e4fbfb6b3de1aa2872b76d49fafc942626e2add",
+        "revCount": 708622,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.708622%2Brev-5e4fbfb6b3de1aa2872b76d49fafc942626e2add/0193363c-ab27-7bbd-af1d-3e6093ed5e2d/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.1.%2A.tar.gz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,20 @@
+{
+  description = "A Nix-flake-based Node.js development environment";
+
+  inputs.nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1.*.tar.gz";
+
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forEachSupportedSystem = f: nixpkgs.lib.genAttrs supportedSystems (system: f {
+        pkgs = import nixpkgs { inherit system; };
+      });
+    in
+    {
+      devShells = forEachSupportedSystem ({ pkgs }: {
+        default = pkgs.mkShell {
+          packages = with pkgs; [ node2nix nodejs nodePackages.pnpm nodePackages.typescript-language-server ];
+        };
+      });
+    };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "@types/node": "^18.0.0",
         "@types/node-fetch": "^2.6.2",
         "@types/wait-on": "^5.3.1",
-        "@webxdc/types": "^2.0.0",
+        "@webxdc/types": "^2.0.1",
         "babel-loader": "^8.2.5",
         "babel-preset-solid": "~1.5.0",
         "concurrently": "^7.2.2",
@@ -3759,10 +3759,11 @@
       }
     },
     "node_modules/@webxdc/types": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@webxdc/types/-/types-2.0.0.tgz",
-      "integrity": "sha512-gtddNq2PsUZZwESXOjpI3sHG185fm7QXEolm9sWVIM1iV0sD4Zs8jLL1MKjuYn04/WuX8jVDKDGBDv4qLimhlA==",
-      "dev": true
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@webxdc/types/-/types-2.1.2.tgz",
+      "integrity": "sha512-oklcyHvUXqCS5JwbPVaN8tt7nSB8ffRmyrUlVt0HeSn4kDyNE46oKSbw3KtrDzl530KHnm67LfcK/AjWbBoXUA==",
+      "dev": true,
+      "license": "unlicense"
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
@@ -13889,9 +13890,9 @@
       "requires": {}
     },
     "@webxdc/types": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@webxdc/types/-/types-2.0.0.tgz",
-      "integrity": "sha512-gtddNq2PsUZZwESXOjpI3sHG185fm7QXEolm9sWVIM1iV0sD4Zs8jLL1MKjuYn04/WuX8jVDKDGBDv4qLimhlA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@webxdc/types/-/types-2.1.2.tgz",
+      "integrity": "sha512-oklcyHvUXqCS5JwbPVaN8tt7nSB8ffRmyrUlVt0HeSn4kDyNE46oKSbw3KtrDzl530KHnm67LfcK/AjWbBoXUA==",
       "dev": true
     },
     "@xtuc/ieee754": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
       "name": "Martijn Faassen",
       "email": "faassen@startifact.com",
       "url": "http://blog.startifact.com"
+    }, 
+    {
+      "name": "Sebastian Klähn",
+      "email": "inf@sebastian-klaehn.de"
     }
   ],
   "files": [

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     }, 
     {
       "name": "Sebastian Klähn",
-      "email": "inf@sebastian-klaehn.de"
+      "email": "info@sebastian-klaehn.de"
     }
   ],
   "files": [

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@types/node": "^18.0.0",
     "@types/node-fetch": "^2.6.2",
     "@types/wait-on": "^5.3.1",
-    "@webxdc/types": "^2.0.0",
+    "@webxdc/types": "^2.0.1",
     "babel-loader": "^8.2.5",
     "babel-preset-solid": "~1.5.0",
     "concurrently": "^7.2.2",

--- a/sim/create.ts
+++ b/sim/create.ts
@@ -1,5 +1,5 @@
-import { WebXdc, ReceivedStatusUpdate } from "@webxdc/types";
-
+import { Webxdc, ReceivedStatusUpdate } from "@webxdc/types";
+import { RTL } from "../backend/message"
 type UpdatesMessage = {
   type: "updates";
   updates: ReceivedStatusUpdate<any>[];
@@ -44,11 +44,11 @@ type Log = (...args: any[]) => void;
 
 export function createWebXdc(
   transport: Transport,
-  log: Log = () => {},
-): WebXdc<any> {
+  log: Log = () => { },
+): Webxdc<any> {
   let resolveUpdateListenerPromise: (() => void) | null = null;
 
-  const webXdc: WebXdc<any> = {
+  const webXdc: Webxdc<any> = {
     sendUpdate: (update, descr) => {
       transport.send({ type: "sendUpdate", update });
       log("send", { update });
@@ -92,17 +92,14 @@ export function createWebXdc(
         );
       }
 
-      /** @type {(file: Blob) => Promise<string>} */
-      const blob_to_base64 = (file) => {
+      const blob_to_base64 = (file: Blob) => {
         const data_start = ";base64,";
         return new Promise((resolve, reject) => {
           const reader = new FileReader();
           reader.readAsDataURL(file);
           reader.onload = () => {
-            /** @type {string} */
-            //@ts-ignore
-            let data = reader.result;
-            resolve(data.slice(data.indexOf(data_start) + data_start.length));
+            let data: string = reader.result as string;
+            resolve(data!.slice(data!.indexOf(data_start) + data_start.length));
           };
           reader.onerror = () => reject(reader.error);
         });
@@ -143,13 +140,11 @@ export function createWebXdc(
           );
         }
       }
-      const msg = `The app would now close and the user would select a chat to send this message:\nText: ${
-        content.text ? `"${content.text}"` : "No Text"
-      }\nFile: ${
-        content.file
+      const msg = `The app would now close and the user would select a chat to send this message:\nText: ${content.text ? `"${content.text}"` : "No Text"
+        }\nFile: ${content.file
           ? `${content.file.name} - ${base64Content.length} bytes`
           : "No File"
-      }`;
+        }`;
       if (content.file) {
         const confirmed = confirm(
           msg + "\n\nDownload the file in the browser instead?",
@@ -191,6 +186,19 @@ export function createWebXdc(
       console.log(element);
       return promise;
     },
+
+    joinRealtimeChannel: () => {
+      return new RTL((data) => {
+        transport.send({ type: "sendRealtime", data });
+        log("send realtime", { data });
+      });
+    },
+    getAllUpdates: () => {
+      console.log("[Webxdc] WARNING: getAllUpdates() is deprecated.");
+      return Promise.resolve([]);
+    },
+    sendUpdateInterval: 1000,
+    sendUpdateMaxSize: 999999,
     selfAddr: transport.address(),
     selfName: transport.name(),
   };

--- a/sim/create.ts
+++ b/sim/create.ts
@@ -1,4 +1,4 @@
-import { Webxdc, ReceivedStatusUpdate, RealtimeListener as WebxdcRealtimeListener } from "@webxdc/types";
+import { Webxdc, ReceivedStatusUpdate } from "@webxdc/types";
 import { RealtimeListener as RTL } from "../backend/message"
 type UpdatesMessage = {
   type: "updates";
@@ -72,8 +72,9 @@ export function createWebXdc(
         } else if (isRealtimeMessage(message)) {
           // TODO: move this out of setUpdateListener because otherwise 
           // You have to set an update listener such that realtime works
-          console.log("received realtime data at frontend")
-          realtime!.receive(message.data)
+          // Conversion to any because the actual data is a dict representation of Uint8Array
+          // This is due to JSON.stringify conversion.
+          realtime!.receive(new Uint8Array(Object.values(message.data as any)))
         } else if (isClearMessage(message)) {
           log("clear");
           transport.clear();

--- a/sim/create.ts
+++ b/sim/create.ts
@@ -50,8 +50,8 @@ export function createWebXdc(
 
   const webXdc: WebXdc<any> = {
     sendUpdate: (update, descr) => {
-      transport.send({ type: "sendUpdate", update, descr });
-      log("send", { update, descr });
+      transport.send({ type: "sendUpdate", update });
+      log("send", { update });
     },
     setUpdateListener: (listener, serial = 0): Promise<void> => {
       transport.onMessage((message) => {

--- a/sim/webxdc.test.ts
+++ b/sim/webxdc.test.ts
@@ -27,8 +27,8 @@ class FakeTransport implements Transport {
 
   send(data: any) {
     if (data.type === "sendUpdate") {
-      const { update, descr } = data;
-      this.client.sendUpdate(update, descr);
+      const { update} = data;
+      this.client.sendUpdate(update, "");
     } else if (data.type === "setUpdateListener") {
       this.client.connect(
         (updates) => {
@@ -106,7 +106,7 @@ test("webxdc sends", async () => {
   }, 0);
   fakeTransport.connect();
   await promise;
-  webXdc.sendUpdate({ payload: "hello" }, "sent 1");
+  webXdc.sendUpdate({ payload: "hello" }, "");
   expect(updates).toEqual([
     {
       payload: "hello",
@@ -148,7 +148,7 @@ test("webxdc distributes", async () => {
   fakeTransportB.connect();
   await promiseB;
 
-  webXdcA.sendUpdate({ payload: "hello" }, "sent 1");
+  webXdcA.sendUpdate({ payload: "hello" }, "");
   expect(updatesA).toEqual([
     {
       payload: "hello",

--- a/sim/webxdc.test.ts
+++ b/sim/webxdc.test.ts
@@ -44,6 +44,15 @@ class FakeTransport implements Transport {
           }
           return true;
         },
+        () => {
+          if (this.messageCallback != null) {
+            this.messageCallback({
+              type: "sendRealtime",
+              data,
+            });
+          }
+          return true;
+        },
         data.serial,
         () => {
           if (this.messageCallback != null) {

--- a/sim/webxdc.test.ts
+++ b/sim/webxdc.test.ts
@@ -31,6 +31,8 @@ class FakeTransport implements Transport {
       this.client.sendUpdate(update, "");
     } else if (data.type === "sendRealtime") {
       this.client.sendRealtimeData(data.data)
+    }else if (data.type === "joinRealtime") {
+      this.client.joinRealtimeChannel()
     } else if (data.type === "setUpdateListener") {
       this.client.connect(
         (updates) => {

--- a/sim/webxdc.test.ts
+++ b/sim/webxdc.test.ts
@@ -29,6 +29,8 @@ class FakeTransport implements Transport {
     if (data.type === "sendUpdate") {
       const { update} = data;
       this.client.sendUpdate(update, "");
+    } else if (data.type === "sendRealtime") {
+      this.client.sendRealtimeData(data.data)
     } else if (data.type === "setUpdateListener") {
       this.client.connect(
         (updates) => {

--- a/sim/webxdc.ts
+++ b/sim/webxdc.ts
@@ -1,4 +1,4 @@
-import { WebXdc } from "@webxdc/types";
+import { Webxdc } from "@webxdc/types";
 import {
   Transport,
   TransportMessageCallback,

--- a/sim/webxdc.ts
+++ b/sim/webxdc.ts
@@ -114,7 +114,7 @@ export class DevServerTransport implements Transport {
   }
 }
 
-function getWebXdc(): WebXdc<any> {
+function getWebXdc(): Webxdc<any> {
   return (window as any).webxdc;
 }
 

--- a/sim/webxdc.ts
+++ b/sim/webxdc.ts
@@ -20,7 +20,7 @@ export class DevServerTransport implements Transport {
 
   constructor(url: string) {
     this.socket = new WebSocket(url);
-    this.promise = new Promise((resolve, reject) => {
+    this.promise = new Promise((resolve) => {
       this.resolveInfo = resolve;
     });
   }
@@ -71,7 +71,7 @@ export class DevServerTransport implements Transport {
         return new Promise((resolve, reject) => {
           const name = result?.name;
           console.log(`Deleting indexedDB database: ${name}`);
-          const request = window.indexedDB.deleteDatabase(name);
+          const request = window.indexedDB.deleteDatabase(name!);
           request.onsuccess = (ev) => resolve(ev);
           request.onerror = (ev) => reject(ev);
         });

--- a/types/message.ts
+++ b/types/message.ts
@@ -17,5 +17,6 @@ export type UpdateMessage =
 
 export type Message =
   | UpdateMessage
+  | ({ type: "realtime-sent", data: Uint8Array} & InstanceMessage)
   | ({ type: "clear" } & InstanceMessage)
   | ({ type: "connect" } & InstanceMessage);

--- a/types/message.ts
+++ b/types/message.ts
@@ -17,6 +17,6 @@ export type UpdateMessage =
 
 export type Message =
   | UpdateMessage
-  | ({ type: "realtime-sent", data: Uint8Array} & InstanceMessage)
+  | ({ type: "sendRealtime", data: Uint8Array} & InstanceMessage)
   | ({ type: "clear" } & InstanceMessage)
   | ({ type: "connect" } & InstanceMessage);

--- a/types/message.ts
+++ b/types/message.ts
@@ -17,6 +17,8 @@ export type UpdateMessage =
 
 export type Message =
   | UpdateMessage
-  | ({ type: "sendRealtime", data: Uint8Array} & InstanceMessage)
+  | ({ type: "sendRealtime", data: Uint8Array } & InstanceMessage)
   | ({ type: "clear" } & InstanceMessage)
-  | ({ type: "connect" } & InstanceMessage);
+  | ({ type: "connect" } & InstanceMessage)
+  | ({ type: "connect-realtime" } & InstanceMessage)
+  | ({ type: "realtime-received"} & InstanceMessage);

--- a/types/message.ts
+++ b/types/message.ts
@@ -21,4 +21,4 @@ export type Message =
   | ({ type: "clear" } & InstanceMessage)
   | ({ type: "connect" } & InstanceMessage)
   | ({ type: "connect-realtime" } & InstanceMessage)
-  | ({ type: "realtime-received"} & InstanceMessage);
+  | ({ type: "realtime-received", data: Uint8Array} & InstanceMessage);


### PR DESCRIPTION
Add support for the webxdc spec realtime APIs. This PR got bigger than expected so I extracted some parts into separate PRs #63 #64 #65. We should merge these first so the diff of this PR gets smaller and more concise. 

Status: If you create the updateListener Handler, you can send and receive realtime messages. Tested this with webxdc/ping webxdc.

Ref: https://webxdc.org/docs/spec/joinRealtimeChannel.html