### PR TITLE
add support for github codespaces

### DIFF
--- a/backend/instance_url.ts
+++ b/backend/instance_url.ts
@@ -1,4 +1,5 @@
 import { isWebContainer, HostURL } from "@webcontainer/env";
+import { env } from "process";
 
 export function getInstanceUrl(port: number) {
   if (isWebContainer()) {
@@ -6,5 +7,9 @@ export function getInstanceUrl(port: number) {
     // This is why we need to convert it here.
     return HostURL.parse(`https://localhost:${port}`).href;
   }
+  if (env["CODESPACE_NAME"]) {
+    return `${env["CODESPACE_NAME"]}-${port}.app.github.dev`
+  }
+
   return `http://localhost:${port}`;
 }

--- a/backend/instance_url.ts
+++ b/backend/instance_url.ts
@@ -8,7 +8,7 @@ export function getInstanceUrl(port: number) {
     return HostURL.parse(`https://localhost:${port}`).href;
   }
   if (env["CODESPACE_NAME"]) {
-    return `${env["CODESPACE_NAME"]}-${port}.app.github.dev`
+    return `${env["CODESPACE_NAME"]}-${port}.app.github.dev`;
   }
 
   return `http://localhost:${port}`;

--- a/sim/webxdc.ts
+++ b/sim/webxdc.ts
@@ -97,6 +97,9 @@ export class DevServerTransport implements Transport {
         /--(\d+)--/.exec(document.location.href)?.[1] ||
         "error in webxdc simulator"
       );
+    } else if (location.host.endsWith(".app.github.dev")) {
+      return /-(\d+)\.app\.github\.dev/.exec(document.location.href)?.[1] ||
+        "error in webxdc simulator"
     } else {
       return document.location.port;
     }

--- a/sim/webxdc.ts
+++ b/sim/webxdc.ts
@@ -98,8 +98,10 @@ export class DevServerTransport implements Transport {
         "error in webxdc simulator"
       );
     } else if (location.host.endsWith(".app.github.dev")) {
-      return /-(\d+)\.app\.github\.dev/.exec(document.location.href)?.[1] ||
+      return (
+        /-(\d+)\.app\.github\.dev/.exec(document.location.href)?.[1] ||
         "error in webxdc simulator"
+      );
     } else {
       return document.location.port;
     }


### PR DESCRIPTION
But currently does not work, because github seems to have a bug, where the iframes with the other ports return the simulator from the main port:
<img width="2191" height="1730" alt="image" src="https://github.com/user-attachments/assets/89ebfa64-68e2-41e5-8aa0-8ed524326fb2" />

Changing port visibility to public on all ports does not help.
