### PR TITLE
clearer startup message

### DIFF
--- a/backend/instance.ts
+++ b/backend/instance.ts
@@ -54,7 +54,7 @@ class Instance {
 
   start() {
     this.server = this.app.listen(this.port, () => {
-      if (env['NODE_DEBUG']) {
+      if (env["NODE_DEBUG"]) {
         console.debug(`Starting webxdc instance at port ${this.port}`);
       }
     });

--- a/backend/run.ts
+++ b/backend/run.ts
@@ -36,12 +36,15 @@ async function actualRun(
   );
 
   frontend.listen(options.basePort, () => {
-    console.info(`\n=> Started webxdc-dev frontend on ${getInstanceUrl(options.basePort)}`);
+    console.info(
+      `\n=> Started webxdc-dev frontend on ${getInstanceUrl(options.basePort)}`,
+    );
   });
 
   instances.start();
 
-  if (!env["CODESPACE_NAME"]) { // do not auto open on gh codespace
+  if (!env["CODESPACE_NAME"]) {
+    // do not auto open on gh codespace
     open("http://localhost:" + options.basePort);
   }
 }


### PR DESCRIPTION
- Log url the user should open in browser and make that log message stand out a bit
- hide instance started messages unless `NODE_DEBUG` is set

closes #73

Before:

```
Starting webxdc project in: .
Starting webxdc-dev frontend
Starting webxdc instance at port 7001
Starting webxdc instance at port 7002
```

After:

```
Starting webxdc project in: ../test-app/

=> Started webxdc-dev frontend on http://localhost:7000
```