### PR TITLE
open the browser with -o, --open like in vite otherwise do nothing

### DIFF
--- a/backend/instance.ts
+++ b/backend/instance.ts
@@ -14,6 +14,7 @@ import { env } from "process";
 
 export type Options = {
   basePort: number;
+  open: boolean;
   csp: boolean;
   verbose: boolean;
 };

--- a/backend/program.ts
+++ b/backend/program.ts
@@ -34,6 +34,7 @@ export function createProgram(inject: Inject): Command {
       parsePort,
       7000,
     )
+    .option("-o, --open", "automatically open webxdc-dev UI in the browser")
     .option("--no-csp", "run instances without CSP applied")
     .option(
       "-v, --verbose",
@@ -46,7 +47,12 @@ export function createProgram(inject: Inject): Command {
     .action(async (location, options) => {
       await run(
         location,
-        { basePort: options.port, csp: options.csp, verbose: options.verbose },
+        {
+          basePort: options.port,
+          open: options.open,
+          csp: options.csp,
+          verbose: options.verbose,
+        },
         inject,
       );
     });

--- a/backend/run.ts
+++ b/backend/run.ts
@@ -43,8 +43,7 @@ async function actualRun(
 
   instances.start();
 
-  if (!env["CODESPACE_NAME"]) {
-    // do not auto open on gh codespace
+  if (options.open) {
     open("http://localhost:" + options.basePort);
   }
 }


### PR DESCRIPTION
pro:
- can be used for automated testing now (no browser needed)
- can still be used for scripts wanting the browser (like start-my-development-environment scripts)
- behavior that vite bundle users would expect. trying to hit a standard here.
- removes the ENV hack
con:
- breaks old behavior