### PR TITLE
Add Drop Updates button to simulate transport failing to deliver messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ are running.
 The dev tool console shows messages with the same color prefix as the instance
 UIs.
 
+You can simulate the host losing messages by toggling the "Drop Updates" button
+on a specific instance. While enabled the instance will not recieve any updates
+as if the transport has failed to deliver them.
+
 #### Clean state
 
 Instances start with a clean slate: empty `localStorage` and `sessionStorage`.

--- a/README.md
+++ b/README.md
@@ -98,10 +98,10 @@ The dev tool console shows messages with the same color prefix as the instance
 UIs.
 
 You can simulate the host losing messages by toggling the `Drop Updates` button
-on a specific instance. While enabled the instance will not recieve any updates
-as if the transport has failed to deliver them. On
-later reloads of the page the instance will load all updates as this state is 
-shared identically between all insances.
+on a specific instance. While enabled the instance will not receive any updates
+as if the transport has failed to deliver them. Note: on later reloads of the
+page the instance will load all updates again because the state is shared between
+all instances in the webxdc-dev backend.
 
 #### Clean state
 

--- a/README.md
+++ b/README.md
@@ -97,9 +97,11 @@ are running.
 The dev tool console shows messages with the same color prefix as the instance
 UIs.
 
-You can simulate the host losing messages by toggling the "Drop Updates" button
+You can simulate the host losing messages by toggling the `Drop Updates` button
 on a specific instance. While enabled the instance will not recieve any updates
-as if the transport has failed to deliver them.
+as if the transport has failed to deliver them. On
+later reloads of the page the instance will load all updates as this state is 
+shared identically between all insances.
 
 #### Clean state
 

--- a/frontend/Instance.tsx
+++ b/frontend/Instance.tsx
@@ -1,4 +1,4 @@
-import { Component, Show } from "solid-js";
+import { Component, Show, createSignal } from "solid-js";
 import { Flex, createDisclosure, notificationService } from "@hope-ui/solid";
 
 import { Instance as InstanceData } from "../types/instance";
@@ -12,12 +12,13 @@ const Instance: Component<{
   setSearch: (search: Search) => void;
 }> = (props) => {
   let iframeRef: HTMLIFrameElement | undefined = undefined;
+  let [dropUpdates, setDropUpdates] = createSignal(false);
 
   const handleReload = () => {
     if (iframeRef == null) {
       return;
     }
-
+    setDropUpdates(false) // reset our state because inner sim/webxdc state is reset in reload
     iframeRef.contentWindow?.postMessage("reload", props.instance.url);
 
     notificationService.show({
@@ -28,6 +29,14 @@ const Instance: Component<{
   const { isOpen, onOpen, onClose } = createDisclosure({
     defaultIsOpen: false,
   });
+
+  const toggleDropUpdates = () => {
+    if (iframeRef == null) {
+      return;
+    }
+    setDropUpdates(!dropUpdates())
+    iframeRef.contentWindow?.postMessage({ name: "dropUpdates", value: dropUpdates()}, props.instance.url)
+  }
 
   const getStyle = () => {
     return {
@@ -49,6 +58,8 @@ const Instance: Component<{
         onStart={onOpen}
         onStop={onClose}
         isStarted={isOpen}
+        dropUpdates={dropUpdates()}
+        onToggleDropUpdates={toggleDropUpdates}
       />
       <Show
         when={isOpen()}

--- a/frontend/InstanceHeader.tsx
+++ b/frontend/InstanceHeader.tsx
@@ -8,7 +8,7 @@ import {
   notificationService,
 } from "@hope-ui/solid";
 import { IoRefreshOutline, IoStop, IoPlay } from "solid-icons/io";
-import { FiExternalLink, FiTrash } from "solid-icons/fi";
+import { FiExternalLink, FiMail, FiTrash } from "solid-icons/fi";
 
 import type { Instance as InstanceData } from "../types/instance";
 import { sent, received, mutateInstances } from "./store";
@@ -21,6 +21,8 @@ const InstanceHeader: Component<{
   onStart: () => void;
   onStop: () => void;
   isStarted: Accessor<boolean>;
+  dropUpdates: boolean;
+  onToggleDropUpdates: () => void;
 }> = (props) => {
   const sentCount = createMemo(() => {
     return sent(props.instance.id);
@@ -112,6 +114,11 @@ const InstanceHeader: Component<{
           label="Delete"
           onClick={() => handleRemoveInstance(props.instance.id)}
           icon={<FiTrash size={22} color="#000000" />}
+        />
+        <InstanceButton
+          label="Drop Updates"
+          onClick={props.onToggleDropUpdates}
+          icon={<FiMail size={22} color={props.dropUpdates ? "#FF0000": "#000000"} />}
         />
       </Flex>
     </Flex>

--- a/frontend/InstanceHeader.tsx
+++ b/frontend/InstanceHeader.tsx
@@ -8,7 +8,8 @@ import {
   notificationService,
 } from "@hope-ui/solid";
 import { IoRefreshOutline, IoStop, IoPlay } from "solid-icons/io";
-import { FiExternalLink, FiMail, FiTrash } from "solid-icons/fi";
+import { FiExternalLink, FiTrash } from "solid-icons/fi";
+import { RiDeviceWifiLine, RiDeviceWifiOffLine } from 'solid-icons/ri'
 
 import type { Instance as InstanceData } from "../types/instance";
 import { sent, received, mutateInstances } from "./store";
@@ -118,7 +119,7 @@ const InstanceHeader: Component<{
         <InstanceButton
           label="Drop Updates"
           onClick={props.onToggleDropUpdates}
-          icon={<FiMail size={22} color={props.dropUpdates ? "#FF0000": "#000000"} />}
+          icon={props.dropUpdates ? <RiDeviceWifiOffLine size={22} color={"#FF0000"} /> : <RiDeviceWifiLine size={22} color={"#000000"} /> }
         />
       </Flex>
     </Flex>

--- a/sim/create.ts
+++ b/sim/create.ts
@@ -112,7 +112,6 @@ export function createWebXdc(
     setUpdateListener: (listener, serial = 0): Promise<void> => {
       transport.onMessage((message) => {
         if (isUpdatesMessage(message)) {
-          log("recv update", message.updates);
           for (const update of message.updates) {
             listener(update);
           }

--- a/sim/webxdc.ts
+++ b/sim/webxdc.ts
@@ -25,12 +25,8 @@ export class DevServerTransport implements Transport {
       this.resolveInfo = resolve;
     });
     window.addEventListener("message", (event) => {
-      const isAllowed =
-        event.origin.includes("localhost:") ||
-        (location.host.endsWith(".webcontainer.io") &&
-          event.origin.includes(".webcontainer.io"));
-      if (!isAllowed) {
-        return;
+      if (!eventIsAllowed(event)) {
+        return
       }
       if (typeof event.data === 'object') {
         if (event.data.name === 'dropUpdates') {
@@ -152,14 +148,16 @@ window.addEventListener("load", () => alterUi(getWebXdc().selfName, transport));
 
 // listen to messages coming into iframe
 window.addEventListener("message", (event) => {
-  const isAllowed =
-    event.origin.includes("localhost:") ||
-    (location.host.endsWith(".webcontainer.io") &&
-      event.origin.includes(".webcontainer.io"));
-  if (!isAllowed) {
-    return;
+  if (!eventIsAllowed(event)) {
+    return
   }
   if (event.data === "reload") {
     window.location.reload();
   }
 });
+
+function eventIsAllowed(event: MessageEvent<any>) {
+  return event.origin.includes("localhost:") ||
+    (location.host.endsWith(".webcontainer.io") &&
+      event.origin.includes(".webcontainer.io"));
+}

--- a/sim/webxdc.ts
+++ b/sim/webxdc.ts
@@ -26,11 +26,11 @@ export class DevServerTransport implements Transport {
     });
     window.addEventListener("message", (event) => {
       if (!eventIsAllowed(event)) {
-        return
+        return;
       }
-      if (typeof event.data === 'object') {
-        if (event.data.name === 'dropUpdates') {
-          this.dropUpdates = event.data.value
+      if (typeof event.data === "object") {
+        if (event.data.name === "dropUpdates") {
+          this.dropUpdates = event.data.value;
         }
       }
     });
@@ -46,7 +46,7 @@ export class DevServerTransport implements Transport {
     }
     const listener = (event: Event): void => {
       if (this.dropUpdates) {
-        return
+        return;
       }
       callback(JSON.parse((event as any).data));
     };
@@ -149,7 +149,7 @@ window.addEventListener("load", () => alterUi(getWebXdc().selfName, transport));
 // listen to messages coming into iframe
 window.addEventListener("message", (event) => {
   if (!eventIsAllowed(event)) {
-    return
+    return;
   }
   if (event.data === "reload") {
     window.location.reload();
@@ -157,7 +157,9 @@ window.addEventListener("message", (event) => {
 });
 
 function eventIsAllowed(event: MessageEvent<any>) {
-  return event.origin.includes("localhost:") ||
+  return (
+    event.origin.includes("localhost:") ||
     (location.host.endsWith(".webcontainer.io") &&
-      event.origin.includes(".webcontainer.io"));
+      event.origin.includes(".webcontainer.io"))
+  );
 }


### PR DESCRIPTION
<img width="415" height="103" alt="image" src="https://github.com/user-attachments/assets/75ff23ea-7ee5-47be-bdb3-321ef4dd5f87" />

This toggles a dropUpdates value inside of the webxdc shim for a particular instance. When new updates come in they will be 'dropped' and not passed into the application. This lets you test what happens when certain devices miss a message!

This doesn't permanently modify the set of updates, so any app the replays them starting from the beginning will see the 'dropped' updates after being restarted. Doing this would require a refactor where we keep track of each instance's update set independently and to properly enumerate them over the websocket connection, probably not worth it for now.